### PR TITLE
Allow automatic updates with Github Updater

### DIFF
--- a/woocommerce-payline.php
+++ b/woocommerce-payline.php
@@ -7,6 +7,8 @@
  * Author: Monext
  * Author URI: http://www.monext.fr
  * License: LGPL-3.0+
+ * GitHub Plugin URI: https://github.com/PaylineByMonext/payline-woocommerce/
+ * Github Branch: master
  * 
  *  Copyright 2017  Monext  (email : support@payline.com)
 


### PR DESCRIPTION
Since the plugin is not on wordpress.org, it would be nice to allow automatic updates with a dedicated plugin "Github Updater".
https://github.com/afragen/github-updater

"Github Updater" requires 2 tags in the plugin header.
GitHub Plugin URI
and
Github Branch

I added them in the header, in this pull request.
Thank you.